### PR TITLE
failed selects display message and improved result table

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -6,7 +6,6 @@ from colorama import Fore, Style
 
 
 def main(argv):
-
     path_under_test = None
     verbose = False
     opts, args = getopt.getopt(argv, "hvp:", ["put="])
@@ -44,10 +43,10 @@ def main(argv):
         for res in results:
             if type(res) == SelectSpecFailure:
                 print(f"Failed {res.spec_uri}")
+                print(res.message)
                 print(res.table_comparison.to_markdown())
             if type(res) == ConstructSpecFailure:
                 print(f"Failed {res.spec_uri}")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When select results do not have matching rows / columns:

- result message shows how many rows / columns were expected and how many are there
- result table shows exact difference