### PR TITLE
processing of sh:order and order by

### DIFF
--- a/src/mustrd.py
+++ b/src/mustrd.py
@@ -5,7 +5,7 @@ from itertools import groupby
 from pathlib import Path
 
 from rdflib import Graph, URIRef, Variable
-from rdflib.namespace import RDF, XSD, SH
+from rdflib.namespace import RDF, XSD
 from rdflib.compare import isomorphic, graph_diff
 from rdflib.term import Literal
 import pandas
@@ -99,11 +99,13 @@ def run_spec(spec_uri, spec_graph) -> SpecResult:
     when = get_when(spec_uri, spec_graph)
     when_type = type(when)
     when_bindings = get_when_bindings(spec_uri, spec_graph)
+
     result = None
 
     if when_type == SelectSparqlQuery:
         then = get_then_select(spec_uri, spec_graph)
-        result = run_select_spec(spec_uri, given, when, then, when_bindings)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        result = run_select_spec(spec_uri, given, when, then, when_bindings, is_ordered)
     elif when_type == ConstructSparqlQuery:
         then = get_then_construct(spec_uri, spec_graph)
         result = run_construct_spec(spec_uri, given, when, then, when_bindings)
@@ -120,32 +122,17 @@ def run_select_spec(spec_uri: URIRef,
                     given: Graph,
                     when: SparqlAction,
                     then: pandas.DataFrame,
-                    bindings: dict = None) -> SpecResult:
+                    bindings: dict = None,
+                    ordered: bool = False) -> SpecResult:
     logging.info(f"Running select spec {spec_uri}")
 
     try:
         result = given.query(when.query, initBindings=bindings)
-        data_dict = {}
-        columns = []
         series_list = []
 
-        for item in result:
-            for key, value in item.asdict().items():
-                if key not in columns:
-                    columns.append(key)
-                    data_dict[key] = []
-                    data_dict[key + "_datatype"] = []
+        columns = get_select_columns(result)
 
-        for item in result:
-            for key, value in item.asdict().items():
-                data_dict[key].append(value)
-                if type(value) == Literal:
-                    literal_type = XSD.string
-                    if hasattr(value, "datatype") and value.datatype:
-                        literal_type = value.datatype
-                    data_dict[key + "_datatype"].append(literal_type)
-                else:
-                    data_dict[key + "_datatype"].append(XSD.anyURI)
+        data_dict = populate_select_columns(columns, result)
 
         # convert dict to Series to avoid problem with array length
         for key, value in data_dict.items():
@@ -153,10 +140,16 @@ def run_select_spec(spec_uri: URIRef,
 
         if series_list:
             df = pandas.concat(series_list, axis=1)
+            when_ordered = False
 
-            if "order by ?" or "order by desc" or "order by asc" not in when.query.lower():
+            if "order by ?" not in when.query.lower() and "order by desc" not in when.query.lower() and "order by asc" not in when.query.lower():
                 df.sort_values(by=columns[::2], inplace=True)
+
                 df.reset_index(inplace=True, drop=True)
+                if ordered:
+                    logging.info(f"sh:order in {spec_uri} is ignored")
+            else:
+                when_ordered = True
 
             # Scenario 1: expected no result but got a result
             if then.empty:
@@ -165,11 +158,21 @@ def run_select_spec(spec_uri: URIRef,
                 df_diff = then.compare(df, result_names=("expected", "actual"))
             else:
                 # Scenario 2: expected a result and got a result
-                message = f"Expected {then.shape[0]} row(s) and {round(then.shape[1] / 2)} column(s), got {df.shape[0]} row(s) and {round(df.shape[1] / 2)} column(s)"
-                if df.shape == then.shape and (df.columns == then.columns).all():
-                    df_diff = then.compare(df, result_names=("expected", "actual"))
+                message = f"Expected {then.shape[0]} row(s) and {round(then.shape[1] / 2)} column(s), " \
+                          f"got {df.shape[0]} row(s) and {round(df.shape[1] / 2)} column(s)"
+                if when_ordered is True and not ordered:
+                    message += ". Actual result is ordered, must:then must contain sh:order on every row."
+                    if df.shape == then.shape and (df.columns == then.columns).all():
+                        df_diff = then.compare(df, result_names=("expected", "actual"))
+                        if df_diff.empty:
+                            df_diff = df
+                    else:
+                        df_diff = construct_df_diff(df, then)
                 else:
-                    df_diff = construct_df_diff(df, then)
+                    if df.shape == then.shape and (df.columns == then.columns).all():
+                        df_diff = then.compare(df, result_names=("expected", "actual"))
+                    else:
+                        df_diff = construct_df_diff(df, then)
         else:
 
             if then.empty:
@@ -275,10 +278,34 @@ def get_when_bindings(spec_uri: URIRef, spec_graph: Graph) -> dict:
         return bindings
 
 
+def is_then_select_ordered(spec_uri: URIRef, spec_graph: Graph) -> bool:
+    ask_select_ordered = f"""
+    ASK {{
+    {{SELECT (count(?binding) as ?totalBindings) {{  
+    <{spec_uri}> <{MUST.then}> ?then .
+ 	?then a <{MUST.TableDataset}> ;
+       <{MUST.rows}> [ <{MUST.row}> [ <{MUST.variable}>  ?variable ;
+                      <{MUST.binding}>  ?binding ;
+                      ] ; ] .
+}} }}
+    {{SELECT (count(?binding) as ?orderedBindings) {{    
+    <{spec_uri}> <{MUST.then}> ?then .
+ 	?then a <{MUST.TableDataset}> ;
+       <{MUST.rows}> [ sh:order ?order ;
+                    <{MUST.row}> [ <{MUST.variable}>  ?variable ;
+                      <{MUST.binding}>  ?binding ;
+                      ] ; ] .
+}} }}
+    FIlTER(?totalBindings = ?orderedBindings)
+}}"""
+    is_ordered = spec_graph.query(ask_select_ordered)
+    return is_ordered.askAnswer
+
+
 def get_then_construct(spec_uri: URIRef, spec_graph: Graph) -> Graph:
     then_query = f"""
     prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-    
+
     CONSTRUCT {{ ?s ?p ?o }}
     {{
         <{spec_uri}> <{MUST.then}> [
@@ -333,13 +360,18 @@ def get_then_select(spec_uri: URIRef, spec_graph: Graph) -> pandas.DataFrame:
         WHERE {{ 
             <{spec_uri}> <{MUST.then}> ?then .
             ?then a <{MUST.TableDataset}> ;
-                  <{MUST.rows}> [ <{SH.order}> 1 ;
-                                  <{MUST.row}> [
+                  <{MUST.rows}> [ <{MUST.row}> [
                                     <{MUST.variable}> ?variable ;
                                     <{MUST.binding}> ?binding ;
                                     ] ; 
                                 ] .
-            }}"""
+            OPTIONAL {{ ?then <{MUST.rows}> [ sh:order ?order ;
+                                            <{MUST.row}> [            
+                                    <{MUST.variable}> ?variable ;
+                                    <{MUST.binding}> ?binding ;
+                                    ] ; 
+                                ] . }}
+            }} ORDER BY ASC(?order)"""
 
         expected_results = spec_graph.query(then_query)
         data_dict = {}
@@ -436,3 +468,32 @@ def create_empty_dataframe_with_columns(original: pandas.DataFrame) -> pandas.Da
     for col in empty_copy.columns:
         empty_copy[col].values[:] = None
     return empty_copy
+
+
+def get_select_columns(result):
+    columns = []
+    for item in result:
+        for key, value in item.asdict().items():
+            if key not in columns:
+                columns.append(key)
+    return columns
+
+
+def populate_select_columns(columns, result):
+    data_dict = {}
+
+    for column in columns:
+        data_dict[column] = []
+        data_dict[column + "_datatype"] = []
+
+    for item in result:
+        for key, value in item.asdict().items():
+            data_dict[key].append(value)
+            if type(value) == Literal:
+                literal_type = XSD.string
+                if hasattr(value, "datatype") and value.datatype:
+                    literal_type = value.datatype
+                data_dict[key + "_datatype"].append(literal_type)
+            else:
+                data_dict[key + "_datatype"].append(XSD.anyURI)
+    return data_dict

--- a/test/test-specs/select_spec.ttl
+++ b/test/test-specs/select_spec.ttl
@@ -14,8 +14,7 @@ test-data:a_complete_select_scenario
     must:when  [ a          must:SelectSparql ;
                  must:query "select ?s ?p ?o { ?s ?p ?o }" ; ] ;
     must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub ; ],
                                       [ must:variable "p" ;
                                         must:binding  test-data:pred ; ],

--- a/test/test-specs/select_spec_multiline_result.ttl
+++ b/test/test-specs/select_spec_multiline_result.ttl
@@ -18,15 +18,13 @@ test-data:a_complete_select_scenario_multiline_result
     must:when  [ a          must:SelectSparql ;
                  must:query "select ?s ?p ?o { ?s ?p ?o }" ; ] ;
     must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub ; ],
                                       [ must:variable "p" ;
                                         must:binding  test-data:pred ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ] ; ] ,
-                            [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                            [ must:row [ must:variable "s" ;
                                         must:binding  test-data:subject ; ],
                                       [ must:variable "p" ;
                                         must:binding  test-data:predicate ; ],

--- a/test/test-specs/select_spec_optional_result.ttl
+++ b/test/test-specs/select_spec_optional_result.ttl
@@ -22,15 +22,13 @@ test-data:a_complete_select_scenario_optional_result
     must:when  [ a          must:SelectSparql ;
                  must:query "select ?s ?o ?object { ?s <https://semanticpartners.com/data/test/pred> ?o . OPTIONAL {?s <https://semanticpartners.com/data/test/predicate> ?object} }" ; ] ;
     must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub1 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ] ,
                                       [ must:variable "object" ;
                                         must:binding  test-data:object ; ] ; ] ,
-                            [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                            [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub2 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ]; ] ;

--- a/test/test-specs/select_spec_ordered.ttl
+++ b/test/test-specs/select_spec_ordered.ttl
@@ -1,0 +1,35 @@
+@prefix rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh:        <http://www.w3.org/ns/shacl#> .
+@prefix must:      <https://mustrd.com/model/> .
+@prefix test-data: <https://semanticpartners.com/data/test/> .
+
+
+test-data:a_complete_select_scenario_ordered
+    a          must:TestSpec ;
+    must:given [ a               must:StatementsDataset ;
+                 must:statements [ a             rdf:Statement ;
+                                   rdf:subject   test-data:sub1 ;
+                                   rdf:predicate test-data:pred1 ;
+                                   rdf:object    test-data:obj1 ; ] ,
+                                   [ a             rdf:Statement ;
+                                   rdf:subject   test-data:sub2 ;
+                                   rdf:predicate test-data:pred2 ;
+                                   rdf:object    test-data:obj2 ; ] ; ] ;
+    must:when  [ a          must:SelectSparql ;
+                 must:query "select ?s ?p ?o { ?s ?p ?o } ORDER BY ?p" ; ] ;
+    must:then  [ a         must:TableDataset ;
+                 must:rows [ sh:order 1 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub1 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred1 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj1 ; ] ; ] ,
+                            [ sh:order 2 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub2 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred2 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj2 ; ] ; ] ;
+               ] .

--- a/test/test-specs/select_spec_variable.ttl
+++ b/test/test-specs/select_spec_variable.ttl
@@ -17,8 +17,7 @@ test-data:a_complete_select_scenario_with_variables
                       must:binding  "hello world" ; ] ;
 ] ;
     must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub ; ],
                                       [ must:variable "p" ;
                                         must:binding  test-data:pred ; ],

--- a/test/test-specs/select_spec_variable_datatypes.ttl
+++ b/test/test-specs/select_spec_variable_datatypes.ttl
@@ -17,8 +17,7 @@ test-data:a_complete_select_scenario_variables_datatypes
                       must:binding  true ; ] ;
 ] ;
     must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub ; ],
                                       [ must:variable "p" ;
                                         must:binding  test-data:pred ; ],

--- a/test/test_run_specs.py
+++ b/test/test_run_specs.py
@@ -27,6 +27,7 @@ class TestRunSpecs:
             SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_expected_empty_result)),
             SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_multiline_result)),
             SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_optional_result)),
+            SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_ordered)),
             SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_variables_datatypes)),
             SpecPassed(URIRef(TEST_DATA.a_complete_select_scenario_with_variables))
         ], f"TTL files in path: {list(test_spec_path.glob('**/*.ttl'))}"

--- a/test/test_select_spec.py
+++ b/test/test_select_spec.py
@@ -3,9 +3,10 @@ from rdflib.namespace import Namespace
 from rdflib.term import Literal, Variable, URIRef
 
 from mustrd import run_select_spec, SpecPassed, SelectSpecFailure, SparqlParseFailure, SelectSparqlQuery, \
-    get_then_select
+    get_then_select, is_then_select_ordered
 
 TEST_DATA = Namespace("https://semanticpartners.com/data/test/")
+
 
 class TestRunSelectSpec:
     def test_select_spec_passes(self):
@@ -28,8 +29,7 @@ class TestRunSelectSpec:
         test-data:my_first_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -72,8 +72,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:wrong-subject ; 
                                         ] ,
@@ -122,8 +121,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -172,8 +170,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -220,8 +217,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec 
            a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:wrong-subject ; 
                                         ] ;
@@ -262,8 +258,7 @@ class TestRunSelectSpec:
         test-data:my_first_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -309,8 +304,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -428,8 +422,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -480,8 +473,7 @@ class TestRunSelectSpec:
         test-data:my_first_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -526,8 +518,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row 
+                        must:rows [ must:row 
                                         [
                                        must:variable "o" ;
                                        must:binding 25.0  ; 
@@ -570,8 +561,7 @@ class TestRunSelectSpec:
         test-data:my_first_spec 
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -583,8 +573,7 @@ class TestRunSelectSpec:
                                        must:variable "o" ;
                                        must:binding test-data:obj  ; 
                                         ]; ] ,
-                                    [ sh:order 1 ;
-                                        must:row [
+                                    [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -628,8 +617,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -677,8 +665,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -730,8 +717,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -780,8 +766,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -833,8 +818,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -846,8 +830,7 @@ class TestRunSelectSpec:
                                        must:variable "o" ;
                                        must:binding test-data:obj  ; 
                                         ]; ] ,
-                                   [ sh:order 1 ;
-                                    must:row [
+                                   [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:subject ; 
                                         ] ,
@@ -901,8 +884,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub1 ; 
                                         ] ,
@@ -914,8 +896,7 @@ class TestRunSelectSpec:
                                        must:variable "o" ;
                                        must:binding test-data:obj1  ; 
                                         ];  ] ,
-                                         [ sh:order 1 ;
-                                    must:row [
+                                    [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub4 ; 
                                         ] ,
@@ -970,15 +951,13 @@ class TestRunSelectSpec:
         test-data:my_first_spec 
             a must:TestSpec ;
             must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub1 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ] ,
                                       [ must:variable "object" ;
                                         must:binding  test-data:object ; ] ; ] ,
-                            [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                            [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub2 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ]; ] ;
@@ -1016,15 +995,13 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then  [ a         must:TableDataset ;
-                 must:rows [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                 must:rows [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub1 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:obj ; ] ,
                                       [ must:variable "object" ;
                                         must:binding  test-data:object ; ] ; ] ,
-                            [ sh:order 1 ;
-                             must:row [ must:variable "s" ;
+                            [ must:row [ must:variable "s" ;
                                         must:binding  test-data:sub2 ; ],
                                       [ must:variable "o" ;
                                         must:binding  test-data:object ; ]; ] ;
@@ -1068,8 +1045,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,
@@ -1121,8 +1097,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:sub ; 
                                         ] ,                                                                               [
@@ -1171,8 +1146,7 @@ class TestRunSelectSpec:
         test-data:my_failing_spec
             a must:TestSpec ;
             must:then [ a must:TableDataset ;
-                        must:rows [ sh:order 1 ;
-                                    must:row [
+                        must:rows [ must:row [
                                        must:variable "s" ;
                                        must:binding test-data:subject ; 
                                         ] , [
@@ -1198,5 +1172,275 @@ class TestRunSelectSpec:
 |  0 |                                                | https://semanticpartners.com/data/test/sub |                                         | http://www.w3.org/2001/XMLSchema#anyURI |                                            | https://semanticpartners.com/data/test/obj    |                                         | http://www.w3.org/2001/XMLSchema#anyURI |                     | https://semanticpartners.com/data/test/pred |                              | http://www.w3.org/2001/XMLSchema#anyURI |
 |  1 |                                                | https://semanticpartners.com/data/test/sub |                                         | http://www.w3.org/2001/XMLSchema#anyURI |                                            | https://semanticpartners.com/data/test/object |                                         | http://www.w3.org/2001/XMLSchema#anyURI |                     | https://semanticpartners.com/data/test/pred |                              | http://www.w3.org/2001/XMLSchema#anyURI |
 |  2 | https://semanticpartners.com/data/test/subject |                                            | http://www.w3.org/2001/XMLSchema#anyURI |                                         | https://semanticpartners.com/data/test/obj |                                               | http://www.w3.org/2001/XMLSchema#anyURI |                                         |                     |                                             |                              |                                         |"""
+        else:
+            raise Exception(f"wrong spec result type {spec_result}")
+
+    def test_select_spec_ordered_passes(self):
+        triples = """
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+        test-data:sub1 test-data:pred1 test-data:obj1 .
+        test-data:sub2 test-data:pred2 test-data:obj2 .
+        """
+
+        state = Graph()
+        state.parse(data=triples, format="ttl")
+        select_query = """
+        select ?s ?p ?o { ?s ?p ?o } ORDER BY ?p
+        """
+        spec_graph = Graph()
+        spec = """
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix must: <https://mustrd.com/model/> .
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+
+        test-data:my_first_spec 
+            a must:TestSpec ;
+            must:then  [ a         must:TableDataset ;
+                 must:rows [ sh:order 1 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub1 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred1 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj1 ; ] ; ] ,
+                            [ sh:order 2 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub2 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred2 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj2 ; ] ; ] ;
+               ] .
+        """
+        spec_graph.parse(data=spec, format='ttl')
+
+        spec_uri = TEST_DATA.my_first_spec
+
+        then_df = get_then_select(spec_uri, spec_graph)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        t = run_select_spec(spec_uri, state, SelectSparqlQuery(select_query), then_df, ordered=is_ordered)
+
+        expected_result = SpecPassed(spec_uri)
+        assert t == expected_result
+
+    def test_select_spec_ordered_fails(self):
+        triples = """
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+        test-data:sub1 test-data:pred1 test-data:obj1 .
+        test-data:sub2 test-data:pred2 test-data:obj2 .
+        """
+
+        state = Graph()
+        state.parse(data=triples, format="ttl")
+        select_query = """
+        select ?s ?p ?o { ?s ?p ?o } ORDER BY ?p
+        """
+        spec_graph = Graph()
+        spec = """
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix must: <https://mustrd.com/model/> .
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+
+        test-data:my_failing_spec
+            a must:TestSpec ;
+            must:then  [ a         must:TableDataset ;
+                 must:rows [ sh:order 2 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub1 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred1 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj1 ; ] ; ] ,
+                            [ sh:order 1 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub2 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred2 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj2 ; ] ; ] ;
+               ] .
+        """
+        spec_graph.parse(data=spec, format='ttl')
+
+        spec_uri = TEST_DATA.my_failing_spec
+
+        then_df = get_then_select(spec_uri, spec_graph)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        spec_result = run_select_spec(spec_uri, state, SelectSparqlQuery(select_query), then_df, ordered=is_ordered)
+        print(spec_result)
+        if type(spec_result) == SelectSpecFailure:
+            table_diff = spec_result.table_comparison.to_markdown()
+            message = spec_result.message
+            assert spec_result.spec_uri == spec_uri
+            assert message == "Expected 2 row(s) and 3 column(s), got 2 row(s) and 3 column(s)"
+            assert table_diff == """|    | ('s', 'expected')                           | ('s', 'actual')                             | ('p', 'expected')                            | ('p', 'actual')                              | ('o', 'expected')                           | ('o', 'actual')                             |
+|---:|:--------------------------------------------|:--------------------------------------------|:---------------------------------------------|:---------------------------------------------|:--------------------------------------------|:--------------------------------------------|
+|  0 | https://semanticpartners.com/data/test/sub2 | https://semanticpartners.com/data/test/sub1 | https://semanticpartners.com/data/test/pred2 | https://semanticpartners.com/data/test/pred1 | https://semanticpartners.com/data/test/obj2 | https://semanticpartners.com/data/test/obj1 |
+|  1 | https://semanticpartners.com/data/test/sub1 | https://semanticpartners.com/data/test/sub2 | https://semanticpartners.com/data/test/pred1 | https://semanticpartners.com/data/test/pred2 | https://semanticpartners.com/data/test/obj1 | https://semanticpartners.com/data/test/obj2 |"""
+        else:
+            raise Exception(f"wrong spec result type {spec_result}")
+
+    def test_select_spec_not_ordered_fails(self):
+        triples = """
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+        test-data:sub1 test-data:pred1 test-data:obj1 .
+        test-data:sub2 test-data:pred2 test-data:obj2 .
+        """
+
+        state = Graph()
+        state.parse(data=triples, format="ttl")
+        select_query = """
+        select ?s ?p ?o { ?s ?p ?o } ORDER BY ?p
+        """
+        spec_graph = Graph()
+        spec = """
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix must: <https://mustrd.com/model/> .
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+
+        test-data:my_failing_spec
+            a must:TestSpec ;
+            must:then  [ a         must:TableDataset ;
+                 must:rows [ must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub1 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred1 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj1 ; ] ; ] ,
+                            [ must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub2 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred2 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj2 ; ] ; ] ;
+               ] .
+        """
+        spec_graph.parse(data=spec, format='ttl')
+
+        spec_uri = TEST_DATA.my_failing_spec
+
+        then_df = get_then_select(spec_uri, spec_graph)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        spec_result = run_select_spec(spec_uri, state, SelectSparqlQuery(select_query), then_df, ordered=is_ordered)
+        print(spec_result)
+        if type(spec_result) == SelectSpecFailure:
+            table_diff = spec_result.table_comparison.to_markdown()
+            message = spec_result.message
+            assert spec_result.spec_uri == spec_uri
+            assert message == "Expected 2 row(s) and 3 column(s), got 2 row(s) and 3 column(s). Actual result is ordered, must:then must contain sh:order on every row."
+            assert table_diff == """|    | s                                           | s_datatype                              | p                                            | p_datatype                              | o                                           | o_datatype                              |
+|---:|:--------------------------------------------|:----------------------------------------|:---------------------------------------------|:----------------------------------------|:--------------------------------------------|:----------------------------------------|
+|  0 | https://semanticpartners.com/data/test/sub1 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/pred1 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/obj1 | http://www.w3.org/2001/XMLSchema#anyURI |
+|  1 | https://semanticpartners.com/data/test/sub2 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/pred2 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/obj2 | http://www.w3.org/2001/XMLSchema#anyURI |"""
+        else:
+            raise Exception(f"wrong spec result type {spec_result}")
+
+    def test_select_spec_not_all_ordered_fails(self):
+        triples = """
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+        test-data:sub1 test-data:pred1 test-data:obj1 .
+        test-data:sub2 test-data:pred2 test-data:obj2 .
+        """
+
+        state = Graph()
+        state.parse(data=triples, format="ttl")
+        select_query = """
+        select ?s ?p ?o { ?s ?p ?o } ORDER BY ?p
+        """
+        spec_graph = Graph()
+        spec = """
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix must: <https://mustrd.com/model/> .
+        @prefix test-data: <https://semanticpartners.com/data/test/> .
+
+        test-data:my_failing_spec
+            a must:TestSpec ;
+            must:then  [ a         must:TableDataset ;
+                 must:rows [ must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub1 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred1 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj1 ; ] ; ] ,
+                            [ sh:order 1 ;
+                             must:row [ must:variable "s" ;
+                                        must:binding  test-data:sub2 ; ],
+                                      [ must:variable "p" ;
+                                        must:binding  test-data:pred2 ; ],
+                                      [ must:variable "o" ;
+                                        must:binding  test-data:obj2 ; ] ; ] ;
+               ] .
+        """
+        spec_graph.parse(data=spec, format='ttl')
+
+        spec_uri = TEST_DATA.my_failing_spec
+
+        then_df = get_then_select(spec_uri, spec_graph)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        spec_result = run_select_spec(spec_uri, state, SelectSparqlQuery(select_query), then_df, ordered=is_ordered)
+        print(spec_result)
+        if type(spec_result) == SelectSpecFailure:
+            table_diff = spec_result.table_comparison.to_markdown()
+            message = spec_result.message
+            assert spec_result.spec_uri == spec_uri
+            assert message == "Expected 2 row(s) and 3 column(s), got 2 row(s) and 3 column(s). Actual result is ordered, must:then must contain sh:order on every row."
+            assert table_diff == """|    | s                                           | s_datatype                              | p                                            | p_datatype                              | o                                           | o_datatype                              |
+|---:|:--------------------------------------------|:----------------------------------------|:---------------------------------------------|:----------------------------------------|:--------------------------------------------|:----------------------------------------|
+|  0 | https://semanticpartners.com/data/test/sub1 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/pred1 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/obj1 | http://www.w3.org/2001/XMLSchema#anyURI |
+|  1 | https://semanticpartners.com/data/test/sub2 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/pred2 | http://www.w3.org/2001/XMLSchema#anyURI | https://semanticpartners.com/data/test/obj2 | http://www.w3.org/2001/XMLSchema#anyURI |"""
+        else:
+            raise Exception(f"wrong spec result type {spec_result}")
+
+    def test_select_spec_expected_fewer_rows_fails(self):
+        triples = """
+            @prefix test-data: <https://semanticpartners.com/data/test/> .
+            test-data:sub test-data:pred test-data:obj .
+            test-data:subject test-data:predicate test-data:object .
+            """
+
+        state = Graph()
+        state.parse(data=triples, format="ttl")
+        select_query = """
+            select ?s ?p ?o { ?s ?p ?o } order by ?p
+            """
+        spec_graph = Graph()
+        spec = """
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix must: <https://mustrd.com/model/> .
+            @prefix test-data: <https://semanticpartners.com/data/test/> .
+
+            test-data:my_failing_spec
+                a must:TestSpec ;
+                must:then [ a must:TableDataset ;
+                            must:rows [ must:row [
+                                           must:variable "s" ;
+                                           must:binding test-data:sub ; 
+                                            ] ,
+                                            [
+                                           must:variable "p" ;
+                                           must:binding test-data:pred ; 
+                                            ] ,
+                                            [
+                                           must:variable "o" ;
+                                           must:binding test-data:obj  ; 
+                                            ];
+                             ] ; ].
+            """
+        spec_graph.parse(data=spec, format='ttl')
+
+        spec_uri = TEST_DATA.my_failing_spec
+
+        then_df = get_then_select(spec_uri, spec_graph)
+        is_ordered = is_then_select_ordered(spec_uri, spec_graph)
+        spec_result = run_select_spec(spec_uri, state, SelectSparqlQuery(select_query), then_df, ordered=is_ordered)
+        print(spec_result)
+        if type(spec_result) == SelectSpecFailure:
+            table_diff = spec_result.table_comparison.to_markdown()
+            message = spec_result.message
+            assert spec_result.spec_uri == spec_uri
+            assert message == "Expected 1 row(s) and 3 column(s), got 2 row(s) and 3 column(s). Actual result is ordered, must:then must contain sh:order on every row."
+            assert table_diff == """|    | ('s', 'expected')   | ('s', 'actual')                                | ('s_datatype', 'expected')   | ('s_datatype', 'actual')                | ('p', 'expected')   | ('p', 'actual')                                  | ('p_datatype', 'expected')   | ('p_datatype', 'actual')                | ('o', 'expected')   | ('o', 'actual')                               | ('o_datatype', 'expected')   | ('o_datatype', 'actual')                |
+|---:|:--------------------|:-----------------------------------------------|:-----------------------------|:----------------------------------------|:--------------------|:-------------------------------------------------|:-----------------------------|:----------------------------------------|:--------------------|:----------------------------------------------|:-----------------------------|:----------------------------------------|
+|  0 |                     | https://semanticpartners.com/data/test/subject |                              | http://www.w3.org/2001/XMLSchema#anyURI |                     | https://semanticpartners.com/data/test/predicate |                              | http://www.w3.org/2001/XMLSchema#anyURI |                     | https://semanticpartners.com/data/test/object |                              | http://www.w3.org/2001/XMLSchema#anyURI |"""
         else:
             raise Exception(f"wrong spec result type {spec_result}")


### PR DESCRIPTION
- if there’s an order by in the query, the expectation must have sh:order on every row, otherwise the test fails. If results are the same by coincidence, only the actual results are show in the table, if there is a mismatch the comparison table is shown.
- if there’s no order by in the query, sh:order is ignored and the test can pass if the expectation matches the actual. It is logged that sh:order is ignored.