### PR TITLE
Using using-graph-uri and using-named-graph-uri query params when update

### DIFF
--- a/mustrd/anzo_utils.py
+++ b/mustrd/anzo_utils.py
@@ -39,8 +39,8 @@ def query_azg(anzo_config: dict, query: str,
         'skipCache': True,
         'format': format,
         'datasourceURI': anzo_config['gqe_uri'],
-        'default-graph-uri': data_layers,
-        'named-graph-uri': data_layers
+        'using-graph-uri' if is_update else 'default-graph-uri': data_layers,
+        'using-named-graph-uri' if is_update else'named-graph-uri': data_layers
     }
     url = f"{anzo_config['url']}/sparql"
     return send_anzo_query(anzo_config, url=url, params=params, query=query, is_update=is_update)


### PR DESCRIPTION
instead of default-graph-uri and named-graph-uri
As it is specified by W3C.
There was an error with anzo before, it seems that it has been fixed