### PR TITLE
Add input layers in data layers for execute select against anzo

### DIFF
--- a/mustrd/mustrdAnzo.py
+++ b/mustrd/mustrdAnzo.py
@@ -40,7 +40,7 @@ def execute_select(triple_store: dict,  when: str, bindings: dict = None) -> str
                             f"FROM <{triple_store['input_graph']}>\nFROM <{triple_store['output_graph']}>").replace(
                                 "${targetGraph}", f"<{triple_store['output_graph']}>")
         # TODO: manage results here
-        return query_azg(anzo_config=triple_store, query=when)
+        return query_azg(anzo_config=triple_store, query=when, data_layers=[triple_store['input_graph']])
     except (ConnectionError, TimeoutError, HTTPError, ConnectTimeout):
         raise
 


### PR DESCRIPTION
That way we set default-graph-uri query param to the input layer and the query doesn't crash if it doesn't contain {fromsource}