### PR TITLE
Add explainer page for mustrd.org

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,26 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs --project-name=mustrd --branch=master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.11.13
+          python-version: "3.11"
 
       - name: Install Python dependencies
         run: pip install flake8

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ test/anzoConnectionConfig.ttl
 pytest.ini
 test/*nogit.py
 test_logs.txt
+.wrangler/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>mustrd: Spec-By-Example for RDF & SPARQL</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --border: #2a2d3a;
+    --text: #e4e4e7;
+    --muted: #8b8d97;
+    --accent: #6ee7b7;
+    --accent2: #93c5fd;
+    --accent3: #fbbf24;
+    --code-bg: #141620;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    font-size: 18px;
+    overflow-x: hidden;
+  }
+
+  .container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 3rem;
+  }
+
+  /* Hero */
+  .hero {
+    text-align: center;
+    padding: 5rem 0 2rem;
+  }
+  .hero h1 {
+    font-size: 3.2rem;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.5rem;
+  }
+  .hero h1 span { color: var(--accent); }
+  .hero .subtitle {
+    font-size: 1rem;
+    color: var(--muted);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+  }
+  .hero .tagline {
+    font-size: 1.2rem;
+    color: var(--text);
+    max-width: 580px;
+    margin: 0 auto;
+  }
+
+  /* Code blocks */
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.5rem;
+    overflow-x: auto;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.88rem;
+    line-height: 1.7;
+    margin: 1.5rem 0;
+  }
+  code {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.88rem;
+  }
+  .kw { color: var(--accent); }
+  .str { color: #fca5a5; }
+  .cm { color: var(--muted); font-style: italic; }
+  .sym { color: var(--accent2); }
+  .lit { color: var(--accent3); }
+
+  /* Sections */
+  section {
+    margin: 4rem 0;
+  }
+  section h2 {
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+  }
+  section h2 span { color: var(--accent); }
+  section > p {
+    color: var(--muted);
+    font-size: 1.05rem;
+    margin-bottom: 1.5rem;
+  }
+
+  /* Feature grid */
+  .features {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin: 2rem 0;
+  }
+  .feature {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+  }
+  .feature h3 {
+    color: var(--accent);
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+  .feature p {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  /* Tables */
+  .sources {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+  }
+  .sources th, .sources td {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+  .sources th {
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .sources td { color: var(--muted); }
+  .sources td:first-child { color: var(--text); }
+
+  /* GWT flow */
+  .gwt {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 1.5rem;
+    margin: 2rem 0;
+  }
+  .gwt-step {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+  }
+  .gwt-step h3 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+  }
+  .gwt-step.given h3 { color: var(--accent); }
+  .gwt-step.when h3 { color: var(--accent2); }
+  .gwt-step.then h3 { color: var(--accent3); }
+  .gwt-step p {
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-bottom: 0.75rem;
+  }
+  .gwt-step pre {
+    font-size: 0.8rem;
+    padding: 0.75rem 1rem;
+    margin: 0;
+  }
+
+  /* CTA */
+  .cta {
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2.5rem;
+    margin: 3rem 0;
+  }
+  .cta h2 { margin-bottom: 1rem; }
+  .cta pre {
+    display: inline-block;
+    margin: 0.75rem 0;
+    font-size: 1rem;
+    padding: 0.75rem 1.5rem;
+    border: none;
+  }
+  .cta p {
+    color: var(--muted);
+    font-size: 0.9rem;
+    margin-top: 1rem;
+  }
+  .cta a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  .cta a:hover { text-decoration: underline; }
+
+  /* Status list */
+  .status-list {
+    list-style: none;
+    margin: 1rem 0;
+  }
+  .status-list li {
+    padding: 0.3rem 0;
+    font-size: 0.95rem;
+    color: var(--muted);
+  }
+  .status-list li::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 0.7rem;
+  }
+  .status-list li.stable::before { background: var(--accent); }
+  .status-list li.impl::before { background: var(--accent3); }
+  .status-list li.planned::before { background: var(--muted); }
+
+  /* Footer */
+  footer {
+    text-align: center;
+    padding: 3rem 0 4rem;
+    border-top: 1px solid var(--border);
+    margin-top: 3rem;
+  }
+  footer p {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  footer a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  footer a:hover { text-decoration: underline; }
+
+  /* Bottle logo */
+  .bottle-logo {
+    display: inline-block;
+    width: 180px;
+    height: 140px;
+    margin-bottom: 1rem;
+  }
+  .bottle-logo svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+  .bottle-group {
+    opacity: 0;
+    animation: bottle-tilt 1.0s ease-out 0.3s forwards;
+    transform-origin: 40px 70px;
+  }
+  @keyframes bottle-tilt {
+    from { opacity: 0; transform: rotate(0deg); }
+    to   { opacity: 1; transform: rotate(35deg); }
+  }
+  .bottle-body {
+    fill: var(--accent3);
+  }
+  .bottle-cap {
+    fill: var(--accent);
+  }
+  .bottle-label {
+    fill: var(--bg);
+  }
+  .bottle-label-text {
+    fill: var(--accent3);
+    font-family: 'Inter', sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+  }
+  .bottle-highlight {
+    fill: rgba(255,255,255,0.15);
+  }
+
+  /* Squirt */
+  .squirt-path {
+    fill: none;
+    stroke: var(--accent3);
+    stroke-width: 4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 120;
+    stroke-dashoffset: 120;
+    opacity: 0;
+    animation: squirt-draw 0.8s ease-out 1.2s forwards;
+  }
+  @keyframes squirt-draw {
+    0%   { opacity: 0; stroke-dashoffset: 120; }
+    10%  { opacity: 0.9; }
+    100% { opacity: 0.9; stroke-dashoffset: 0; }
+  }
+  .squirt-drops circle {
+    fill: var(--accent3);
+    opacity: 0;
+  }
+  .squirt-drops circle:nth-child(1) {
+    animation: drop-appear 0.4s ease-out 1.8s forwards;
+  }
+  .squirt-drops circle:nth-child(2) {
+    animation: drop-appear 0.4s ease-out 2.0s forwards;
+  }
+  .squirt-drops circle:nth-child(3) {
+    animation: drop-appear 0.4s ease-out 2.15s forwards;
+  }
+  @keyframes drop-appear {
+    from { opacity: 0; transform: translateY(-3px); }
+    to   { opacity: 0.7; transform: translateY(0); }
+  }
+
+  /* Squeeze on hover */
+  .bottle-group.ready {
+    animation: none;
+    opacity: 1;
+    transform: rotate(35deg);
+    transition: transform 0.25s ease-in-out;
+  }
+  .bottle-logo:hover .bottle-group.ready {
+    transform: rotate(38deg) scaleX(0.92);
+  }
+
+  @media (max-width: 768px) {
+    .features, .gwt { grid-template-columns: 1fr; }
+    .hero h1 { font-size: 2.2rem; }
+    .container { padding: 0 1.5rem; }
+    .bottle-logo { width: 140px; height: 110px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="container">
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="bottle-logo" title="mustrd">
+      <svg viewBox="0 0 180 140" xmlns="http://www.w3.org/2000/svg">
+        <!-- Bottle (tilts into position) -->
+        <g class="bottle-group">
+          <!-- Bottle body -->
+          <path class="bottle-body" d="
+            M28,52 C28,48 30,44 32,42
+            C33,40 33,38 33,36
+            L33,28 L47,28 L47,36
+            C47,38 47,40 48,42
+            C50,44 52,48 52,52
+            L54,100 C54,108 50,112 40,112
+            C30,112 26,108 26,100 Z" />
+          <!-- Highlight stripe -->
+          <path class="bottle-highlight" d="
+            M30,54 C30,50 31,46 33,44
+            L33,36 L36,36 L36,44
+            C34,46 33,50 33,54
+            L31,100 C31,104 32,106 34,108
+            L31,108 C29,106 28,104 28,100 Z" />
+          <!-- Label -->
+          <rect class="bottle-label" x="29" y="68" width="22" height="28" rx="3" />
+          <text class="bottle-label-text" x="40" y="86" text-anchor="middle">M</text>
+          <!-- Cap -->
+          <rect class="bottle-cap" x="31" y="16" width="18" height="14" rx="3" />
+          <!-- Nozzle tip -->
+          <path class="bottle-cap" d="M36,16 L36,12 C36,10 38,8 40,8 C42,8 44,10 44,12 L44,16 Z" />
+        </g>
+        <!-- Squirt arc (drawn after bottle tilts) -->
+        <path class="squirt-path" d="
+          M76,19 C86,24 96,42 106,52
+          Q116,62 126,66 Q136,70 146,68
+          Q156,66 162,72 Q168,78 164,86" />
+        <!-- Trailing drops -->
+        <g class="squirt-drops">
+          <circle cx="168" cy="94" r="2.5" />
+          <circle cx="163" cy="102" r="2" />
+          <circle cx="170" cy="108" r="1.5" />
+        </g>
+      </svg>
+    </div>
+    <h1><span>mustrd</span></h1>
+    <div class="subtitle">Spec-By-Example for RDF &amp; SPARQL</div>
+    <p class="tagline">Test your SPARQL queries and transformations with precision, using Given-When-Then principles.</p>
+  </section>
+
+  <!-- Core example -->
+  <section>
+    <pre><span class="cm"># One spec. Given data. When query. Then result.</span>
+<span class="kw">:my_test</span>
+    <span class="sym">must:given</span> [ a <span class="kw">must:FileDataset</span> ;
+                 <span class="sym">must:file</span> <span class="str">"test/data/given.ttl"</span> ] ;
+    <span class="sym">must:when</span>  [ a <span class="kw">must:TextSparqlSource</span> ;
+                 <span class="sym">must:queryText</span> <span class="str">"CONSTRUCT { ?s ?p ?o }
+                                WHERE { ?s a ex:Person ; ?p ?o }"</span> ;
+                 <span class="sym">must:queryType</span> <span class="kw">must:ConstructSparql</span> ] ;
+    <span class="sym">must:then</span>  [ a <span class="kw">must:FileDataset</span> ;
+                 <span class="sym">must:file</span> <span class="str">"test/data/expected.ttl"</span> ] .</pre>
+    <p>Define your data, run your query, check the result. All in Turtle.</p>
+  </section>
+
+  <!-- What mustrd is -->
+  <section>
+    <h2>What <span>mustrd</span> is</h2>
+    <div class="features">
+      <div class="feature">
+        <h3>A pytest plugin</h3>
+        <p>Add <code>--mustrd</code> to your pytest command. Specs become tests. Results show in your runner, CI, and VS Code.</p>
+      </div>
+      <div class="feature">
+        <h3>Triplestore agnostic</h3>
+        <p>Run specs against embedded RDFLib, GraphDB, or Anzo. Same specs, different engines. Swap with configuration, not code.</p>
+      </div>
+      <div class="feature">
+        <h3>Spec-By-Example</h3>
+        <p>Inspired by Cucumber. Define concrete examples of what your query should do, not abstract assertions about what it might.</p>
+      </div>
+      <div class="feature">
+        <h3>Not SHACL</h3>
+        <p>SHACL validates data structure. mustrd validates data transformations. Your query produces the right triples? mustrd checks.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Given-When-Then -->
+  <section>
+    <h2><span>Given</span>-When-Then</h2>
+    <p>Every spec follows the same shape. Load data, run a query, check the output.</p>
+    <div class="gwt">
+      <div class="gwt-step given">
+        <h3>Given</h3>
+        <p>The input dataset. A Turtle file, inline statements, an Anzo graphmart, or inherited state.</p>
+        <pre><span class="sym">must:given</span> [
+  a <span class="kw">must:FileDataset</span> ;
+  <span class="sym">must:file</span> <span class="str">"data/input.ttl"</span>
+] ;</pre>
+      </div>
+      <div class="gwt-step when">
+        <h3>When</h3>
+        <p>The SPARQL action. Inline text, a file reference, or a query builder source. SELECT, CONSTRUCT, or UPDATE.</p>
+        <pre><span class="sym">must:when</span> [
+  a <span class="kw">must:FileSparqlSource</span> ;
+  <span class="sym">must:file</span> <span class="str">"sparql/enrich.rq"</span> ;
+  <span class="sym">must:queryType</span> <span class="kw">must:UpdateSparql</span>
+] ;</pre>
+      </div>
+      <div class="gwt-step then">
+        <h3>Then</h3>
+        <p>The expected result. An RDF graph, a table of bindings, CSV/Excel, or an empty result.</p>
+        <pre><span class="sym">must:then</span> [
+  a <span class="kw">must:FileDataset</span> ;
+  <span class="sym">must:file</span> <span class="str">"data/expected.ttl"</span>
+] .</pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- Query types -->
+  <section>
+    <h2>Query <span>types</span></h2>
+    <p>mustrd validates across SPARQL's full query surface.</p>
+    <table class="sources">
+      <tr><th>Type</th><th>What it does</th><th>Result compared as</th></tr>
+      <tr><td>SELECT</td><td>Return variable bindings</td><td>Table (pandas DataFrame)</td></tr>
+      <tr><td>CONSTRUCT</td><td>Build an RDF graph</td><td>Graph isomorphism</td></tr>
+      <tr><td>UPDATE</td><td>INSERT/DELETE triples</td><td>Modified graph comparison</td></tr>
+      <tr><td>ASK</td><td>Boolean existence check</td><td>True/false</td></tr>
+      <tr><td>DESCRIBE</td><td>Describe a resource</td><td>Graph isomorphism</td></tr>
+    </table>
+  </section>
+
+  <!-- Triplestores -->
+  <section>
+    <h2>Triplestore <span>support</span></h2>
+    <p>Write specs once. Run them against any supported engine.</p>
+    <table class="sources">
+      <tr><th>Engine</th><th>Protocol</th><th>Notes</th></tr>
+      <tr><td>RDFLib</td><td>Embedded (in-memory)</td><td>Default. No server needed. Zero config.</td></tr>
+      <tr><td>GraphDB</td><td>HTTP SPARQL endpoint</td><td>Repository-based. Optional named graphs.</td></tr>
+      <tr><td>Anzo</td><td>HTTP REST API</td><td>Graphmart layers, query builders, AnzoGraph.</td></tr>
+    </table>
+  </section>
+
+  <!-- Dataset types -->
+  <section>
+    <h2>Flexible <span>datasets</span></h2>
+    <p>Givens and thens support multiple data formats.</p>
+    <table class="sources">
+      <tr><th>Type</th><th>Description</th></tr>
+      <tr><td>FileDataset</td><td>RDF file &mdash; Turtle, NTriples, N3, RDF/XML, TriX</td></tr>
+      <tr><td>StatementsDataset</td><td>Inline reified RDF statements in the spec</td></tr>
+      <tr><td>TableDataset</td><td>Inline tabular bindings for SELECT results</td></tr>
+      <tr><td>OrderedTableDataset</td><td>Tabular data with row ordering (ORDER BY)</td></tr>
+      <tr><td>FolderDataset</td><td>File path passed as a runtime argument</td></tr>
+      <tr><td>EmptyTable / EmptyGraph</td><td>Expect no results</td></tr>
+      <tr><td>InheritedDataset</td><td>Keep existing graph state (chain specs)</td></tr>
+    </table>
+  </section>
+
+  <!-- IDE Integration -->
+  <section>
+    <h2>VS Code <span>integration</span></h2>
+    <p>Specs appear as tests in the Test Explorer. Click to run, see diffs on failure.</p>
+    <pre><span class="cm">// settings.json</span>
+{
+  <span class="str">"python.testing.pytestArgs"</span>: [
+    <span class="str">"--mustrd"</span>,
+    <span class="str">"--md=junit/github_job_summary.md"</span>,
+    <span class="str">"--config=test/test_config_local.ttl"</span>
+  ]
+}</pre>
+  </section>
+
+  <!-- Status -->
+  <section>
+    <h2>Status</h2>
+    <ul class="status-list">
+      <li class="stable">RDFLib executor: stable</li>
+      <li class="stable">SELECT / CONSTRUCT / UPDATE specs: stable</li>
+      <li class="stable">SHACL spec validation: stable</li>
+      <li class="stable">pytest plugin with VS Code: stable</li>
+      <li class="stable">GraphDB integration: stable</li>
+      <li class="stable">Anzo integration: stable</li>
+      <li class="impl">Markdown test reports: implemented</li>
+      <li class="impl">GitHub Actions CI summary: implemented</li>
+    </ul>
+  </section>
+
+  <!-- Get started -->
+  <section class="cta">
+    <h2>Get <span>started</span></h2>
+    <pre>pip install mustrd</pre>
+    <pre>pytest --mustrd --config=test/mustrd_configuration.ttl</pre>
+    <p><a href="https://github.com/Semantic-partners/mustrd">GitHub</a> &middot; <a href="mailto:mustrd@semanticpartners.com">mustrd@semanticpartners.com</a></p>
+  </section>
+
+  <footer>
+    <p><a href="https://www.semanticpartners.com">Semantic Partners</a> &mdash; specialist consultancy in Semantic Technology</p>
+  </footer>
+
+</div>
+
+<script>
+document.querySelector('.bottle-group').addEventListener('animationend', function() {
+  this.classList.add('ready');
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds an `index.html` explainer page in `docs/` for hosting on mustrd.org via GitHub Pages

## Next steps
- Enable GitHub Pages on `docs/` folder in repo settings
- Point mustrd.org DNS (CNAME) to `semantic-partners.github.io`
- Add CNAME file to `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)