### PR TITLE
Fix ontology URL routing on Pages

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,3 @@
+/model/ /model 301
+/triplestore/ /triplestore 301
+/mustrdTest/ /mustrdTest 301

--- a/docs/_routes.json
+++ b/docs/_routes.json
@@ -1,5 +1,21 @@
 {
   "version": 1,
-  "include": ["/model*", "/triplestore*", "/mustrdTest*"],
-  "exclude": ["/model/*", "/triplestore/*", "/mustrdTest/*"]
+  "include": [
+    "/model",
+    "/model.ttl",
+    "/model.rdf",
+    "/model.jsonld",
+    "/model.nt",
+    "/triplestore",
+    "/triplestore.ttl",
+    "/triplestore.rdf",
+    "/triplestore.jsonld",
+    "/triplestore.nt",
+    "/mustrdTest",
+    "/mustrdTest.ttl",
+    "/mustrdTest.rdf",
+    "/mustrdTest.jsonld",
+    "/mustrdTest.nt"
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
## Summary

Follow-up to #226. After deploy, `mustrd.pages.dev/model` fell through to `index.html` (the explainer) instead of invoking the content-negotiation Function.

## Root cause

1. `_routes.json` used `"/model*"` etc. CF Pages' glob treats `*` as "one or more characters", so `/model*` matches `/model.ttl` but not bare `/model`. The bare slug was routed as a static asset, didn't match any file, and CF's SPA fallback served `/index.html`.
2. The namespace IRIs all end in `/` (`https://mustrd.org/model/` etc.), but the Function only matches the no-slash form.

## Changes

- [docs/_routes.json](docs/_routes.json): enumerate each slug and extension explicitly (`/model`, `/model.ttl`, `/model.rdf`, `/model.jsonld`, `/model.nt`, × 3 namespaces).
- [docs/_redirects](docs/_redirects): 301 `/model/` → `/model`, `/triplestore/` → `/triplestore`, `/mustrdTest/` → `/mustrdTest`. So dereferencing the namespace IRI (with trailing slash) still reaches the Function.

## Test plan

- [ ] Merge, wait for deploy
- [ ] `curl -sI https://mustrd.pages.dev/model` → 200 text/html (the ontology doc, NOT the explainer)
- [ ] `curl -sI -H "Accept: text/turtle" https://mustrd.pages.dev/model` → 200 text/turtle
- [ ] `curl -sI https://mustrd.pages.dev/model/` → 301 redirect to /model
- [ ] `curl -sI https://mustrd.pages.dev/model/ontology.ttl` → still serves the raw source file
- [ ] `curl -sI https://mustrd.pages.dev/` → still the explainer (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)